### PR TITLE
Include NOTICE files

### DIFF
--- a/app/collect.js
+++ b/app/collect.js
@@ -32,7 +32,7 @@ function _extractPackageInformations(modules) {
     return modules;
 }
 
-function _findLicenseFile(modules) {
+function _findLicenseFiles(modules) {
     for (let i = 0 ; i < modules.length ; i++) {
         let module = modules[i];
         var files = fs.readdirSync(module.path);
@@ -40,7 +40,10 @@ function _findLicenseFile(modules) {
         for (var j = 0 ; j < files.length ; j++) {
             if (files[j].match(/(LICENSE|LICENCE|COPYING)/i)) {
                 module.licenseFile = files[j];
-                break;
+                if (module.hasOwnProperty('noticeFile')) break;
+            } else if (files[j].match(/NOTICE/i)) {
+                module.noticeFile = files[j];
+                if (module.hasOwnProperty('licenseFile')) break;
             }
         }
     }
@@ -50,10 +53,12 @@ function _findLicenseFile(modules) {
 function _readLicenseText(modules) {
     for (let i = 0 ; i < modules.length ; i++) {
         let module = modules[i];
-        if (!module.licenseFile) {
-            continue;
+        if (module.licenseFile) {
+            module.licenseText = fs.readFileSync(path.join(module.path, module.licenseFile)).toString().replace(/\r?\n/g, "\n");
         }
-        module.licenseText = fs.readFileSync(path.join(module.path, module.licenseFile)).toString().replace(/\r?\n/g, "\n");
+        if (module.noticeFile) {
+            module.noticeText = fs.readFileSync(path.join(module.path, module.noticeFile)).toString().replace(/\r?\n/g, "\n");
+        }
     }
     return modules;
 }
@@ -61,7 +66,7 @@ function _readLicenseText(modules) {
 function collectInformations(modules) {
     return Q(modules)
         .then(_extractPackageInformations)
-        .then(_findLicenseFile)
+        .then(_findLicenseFiles)
         .then(_readLicenseText);
 }
 

--- a/app/format.js
+++ b/app/format.js
@@ -19,7 +19,8 @@ function formatTable(modules) {
         chalk.cyan.bold("Module Name"),
         chalk.cyan.bold("Version"),
         chalk.cyan.bold("License"),
-        chalk.cyan.bold("License File")
+        chalk.cyan.bold("License File"),
+        chalk.cyan.bold("Notice File")
     ]);
 
     for (let i = 0 ; i < modules.length ; i++) {
@@ -28,7 +29,8 @@ function formatTable(modules) {
             chalk.bold(module.name),
             module.version,
             (module.license.match(/bsd|mit|apache|isc/i)) ? module.license : chalk.yellow(module.license),
-            module.licenseFile ? chalk.green("Yes") : chalk.red("No")
+            module.licenseFile ? chalk.green("Yes") : chalk.red("No"),
+            module.noticeFile ? chalk.green("Yes") : "No"
         ]);
     }
 
@@ -50,6 +52,13 @@ function formatFull(modules) {
         result += `${module.name} ${module.version} - License ${module.license}\n`;
         result += `downloaded from <https://www.npmjs.com/package/${module.name}>\n`;
         result += "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+        if (module.noticeText) {
+            result += module.noticeText;
+            if (module.noticeText[module.noticeText.length-1] !== "\n") {
+                result += "\n";
+            }
+            result += "\n";
+        }
         if (module.licenseText) {
             result += module.licenseText;
             if (module.licenseText[module.licenseText.length-1] !== "\n") {


### PR DESCRIPTION
This PR teaches brlicenses to find and copy NOTICE files.

[The Apache License in particular](https://www.apache.org/licenses/LICENSE-2.0.html#redistribution) requires copies of any NOTICE files for redistribution.

Thank you so much for this package! I plan to include a tutorial on how to use it [like this](https://github.com/kemitchell/browserify-license-copies.js/blob/master/package.json#L11) in my licensing workshopper, [shark repellent](https://www.npmjs.com/package/shark-repellent).

All the best from Oakland, California.

K
