### PR TITLE
Add licenseURLs to JSON model & output

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "q": "^1.4.1",
     "table": "^3.7.8",
     "through2": "^2.0.1",
-    "yargs": "^4.7.1"
+    "yargs": "^4.7.1",
+    "spdx-expression-parse": "^1.0.2"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
I'd appreciate consideration to include this.

Some tools provide links to the licenses rather than the full license text, this provides a means of extracting links from the JSON output in these cases. This handles basic cases of using a SPDX expression or other common methods to identify the license used, including a custom URL.
