### PR TITLE
Gulp librejs extensions

### DIFF
--- a/app/formats/index.js
+++ b/app/formats/index.js
@@ -4,5 +4,6 @@ module.exports = {
     table: require("./table.js"),
     short: require("./short.js"),
     full: require("./full.js"),
-    json: require("./json.js")
+    json: require("./json.js"),
+    jsObject: require("./js-object.js"),
 };

--- a/app/formats/js-object.js
+++ b/app/formats/js-object.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function formatJsObject(modules) {
+    return modules;
+}
+
+module.exports = formatJsObject;

--- a/app/index.js
+++ b/app/index.js
@@ -11,7 +11,7 @@ function _source(browserify, modules, json, ignore) {
     var sourcePromises = [];
 
     if (browserify) {
-        sourcePromises.push(sources.browserify(browserify, ignore));
+        sourcePromises.push(sources.browserify.external(browserify, ignore));
     }
 
     if (modules) {

--- a/app/index.js
+++ b/app/index.js
@@ -38,9 +38,12 @@ function _sort(modules) {
 }
 
 module.exports = function(options) {
-    return _source(options.browserify, options.modules, options.json, options.ignore)
+    var resultingPromise = _source(options.browserify, options.modules, options.json, options.ignore)
         .then(_filterIgnored.bind(undefined, options.ignore))
         .then(_sort)
-        .then(formats[options.format])
-        .then(options.output ? writers.file.bind(undefined, options.output) : writers.stdout);
+        .then(formats[options.format]);
+    if (options.output != 'none') {
+        resultingPromise.then(options.output ? writers.file.bind(undefined, options.output) : writers.stdout);
+    }
+    return resultingPromise;
 };

--- a/app/sources/browserify.js
+++ b/app/sources/browserify.js
@@ -55,10 +55,26 @@ function _fileListToModule(files) {
     return modules;
 }
 
-function sourceBrowserify(entryPointsPath, ignore) {
+function sourceBrowserifyExternal(entryPointsPath, ignore) {
     return _listBundledFiles(entryPointsPath, ignore)
         .then(_fileListToModule)
         .then(extractors.nodeModule);
 }
 
-module.exports = sourceBrowserify;
+function sourceBrowserifyInternal(entryPointsPath, ignore) {
+    return _listBundledFiles(entryPointsPath, ignore)
+        .then(function (files) {
+            var modules = [];
+            for (let i = 0 ; i < files.length ; i++) {
+                if (files[i].indexOf("node_modules") < 0 && files[i] != entryPointsPath) {
+                    modules.push(files[i]);
+                }
+            }
+            return modules;
+        });
+}
+
+module.exports = {
+    external: sourceBrowserifyExternal,
+    internal: sourceBrowserifyInternal
+};


### PR DESCRIPTION
We are working on a gulp-librejs plugin, which calls browserify-licenses internally to get license information of dependencies. To seamlessly integrate browserify-licenses functionality, we need the following extensions:
* output option: 'none'
* formatter, that does not do any formatting, but simply passes on/ returns the object list
* browserify source parsing that can either analyse external dependencies (npm package dependencies) or internal dependencies (other local js files)